### PR TITLE
don't use document's language for datepicker language

### DIFF
--- a/vendor/assets/javascripts/hobo-bootstrap-ui/bootstrap-datepicker.js
+++ b/vendor/assets/javascripts/hobo-bootstrap-ui/bootstrap-datepicker.js
@@ -1,3 +1,3 @@
 $(function() {
-  $('.bootstrap-datepicker').datepicker({ language: document.documentElement.lang });
+  $('.bootstrap-datepicker').datepicker();
 });


### PR DESCRIPTION
as document's language is hardcoded to 'en' in https://github.com/Hobo/hobo_bootstrap/blob/master/taglibs/page.dryml#L31

this is one potential way of fixing it, see discussion at: https://groups.google.com/forum/#!searchin/hobousers/datepicker/hobousers/0eBz-C9Plr8/sPevKOYust8J
